### PR TITLE
fix : fix bugs in f1loss

### DIFF
--- a/v2/loss.py
+++ b/v2/loss.py
@@ -47,12 +47,15 @@ class LabelSmoothingLoss(nn.Module):
 # F1 Score는 precision과 recall의 조화 평균이며, 이를 손실로 사용한다.
 # https://gist.github.com/SuperShinyEyes/dcc68a08ff8b615442e3bc6a9b55a354
 class F1Loss(nn.Module):
-    def __init__(self, classes=3, epsilon=1e-7):
+    def __init__(self, classes=18, epsilon=1e-7):
         super().__init__()
         self.classes = classes
         self.epsilon = epsilon
 
     def forward(self, y_pred, y_true):
+        if(y_pred.ndim==1):
+            y_pred=y_pred.unsqueeze(0)
+            y_true=y_true.unsqueeze(0)
         assert y_pred.ndim == 2
         assert y_true.ndim == 1
         y_true = F.one_hot(y_true, self.classes).to(torch.float32)


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->

## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
loss.py파일의 f1loss를 사용할경우 일어나는 에러 수정
-

## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
f1loss의 default classes수를 18로 변경, AccuracyLoss function에서 criterion을 호출할 경우에도 정상적으로 실행되도록 수정
-

## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
loss.py의 f1loss에서 y_pred는 (batch,classes) 형태의 2차원 텐서여야 합니다.
하지만 AccuracyLoss 내에서 batch의 개별적 데이터에 대해 criterion을 호출할때 (1,classes)의 형태가 아닌 (classes)형태로 인자를 넘기므로 해당 경우에도 f1loss가 잘 실행되도록 unsqueeze를 사용하여 dimension을 맞춰주었습니다.
y_true또한 같은 방법으로 차원을 맞춰주었습니다.
-

## 💡Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #4242") -->

-
